### PR TITLE
callback fix when does not click on option

### DIFF
--- a/dist/jquery.convform.js
+++ b/dist/jquery.convform.js
@@ -116,12 +116,6 @@ ConvState.prototype.printAnswers = function(answers, multiple){
                         this.answerWith($(event.target).data("answer").text, $(event.target).data("answer"));
                         this.wrapper.find('div.options div.option').remove();
                     }.bind(this));
-                if(answers[i].hasOwnProperty('callback')){
-                  var callback = answers[i].callback;
-                	option.click(function(event){
-                		window[this]();
-                	}.bind(callback));
-                }
                 this.wrapper.find('div.options').append(option);
                 $(window).trigger('dragreset');
             }
@@ -163,6 +157,9 @@ ConvState.prototype.answerWith = function(answerText, answerObject) {
     $(this.wrapper).find("#userInput").focus();
     setTimeout(function(){
         $(this.wrapper).find("#messages").append(message);
+        if (answerObject.hasOwnProperty('callback')) {
+            window[answerObject.callback]();
+        }
         this.scrollDown();
     }.bind(this), 300);
 
@@ -201,8 +198,8 @@ ConvState.prototype.answerWith = function(answerText, answerObject) {
                     var answer = {};
                     answer['text'] = $(this).text();
                     answer['value'] = $(this).val();
-		            if($(this).attr('callback'))
-		            	answer['callback'] = $(this).attr('callback');
+                    if($(this).attr('callback'))
+                        answer['callback'] = $(this).attr('callback');
                     return answer;
                 }).get();
                 if($(this).prop('multiple')){


### PR DESCRIPTION
This is just a quick fix for something I noticed when a user selects an answer by hitting 'enter' on the chat, the option is selected but the callback isn't triggered as it was only bound by a 'click' event.